### PR TITLE
Configure postgres recovery.conf via environment variables

### DIFF
--- a/clicmd/run_agent.go
+++ b/clicmd/run_agent.go
@@ -56,7 +56,8 @@ func RunAgent(c *cli.Context) {
 func createPatroniPostgresConfigFiles(clusterSpec *config.ClusterSpecification, rootPath string, postgresUser string) (err error) {
 	fmt.Println(*clusterSpec)
 
-	patroniSpec, err := config.BuildPatroniSpec(clusterSpec, config.HostDiscoverySpec())
+	patroniSpec, err := config.BuildPatroniSpec(
+		clusterSpec, config.HostDiscoverySpec(), config.OverrideSpec())
 	if err != nil {
 		return errwrap.Wrapf("Cannot BuildPatroniSpec: {{err}}", err)
 	}

--- a/config/override_discovery.go
+++ b/config/override_discovery.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"log"
+
+	"github.com/kelseyhightower/envconfig"
+)
+
+// OverrideSpecification collects all user overrides from environment variables
+type OverrideSpecification struct {
+	PostgresRecovery *PostgresRecoveryOverrideSpecification
+}
+
+// PostgresRecoveryOverrideSpecification imports postgres recovery overrides from environment variables
+type PostgresRecoveryOverrideSpecification struct {
+	TargetName      string `envconfig:"pg_recovery_target_name"`
+	TargetTime      string `envconfig:"pg_recovery_target_time"`
+	TargetXid       string `envconfig:"pg_recovery_target_xid"`
+	TargetInclusive bool   `envconfig:"pg_recovery_target_inclusive"`
+	TargetTimeline  string `envconfig:"pg_recovery_target_timeline"`
+	TargetAction    string `envconfig:"pg_recovery_target_action"`
+}
+
+// OverrideSpec collects all the user overrides into single struct
+func OverrideSpec() (override *OverrideSpecification) {
+	override = &OverrideSpecification{}
+	override.PostgresRecovery = loadPostgresRecoveryOverrides()
+	return
+}
+
+func loadPostgresRecoveryOverrides() (spec *PostgresRecoveryOverrideSpecification) {
+	spec = &PostgresRecoveryOverrideSpecification{}
+	err := envconfig.Process("pg_recovery", spec)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	return
+}

--- a/config/override_discovery_test.go
+++ b/config/override_discovery_test.go
@@ -1,0 +1,18 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestOverrideDiscovery(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("PG_RECOVERY_TARGET_TIMELINE", "latest")
+
+	spec := OverrideSpec()
+	if spec.PostgresRecovery.TargetTimeline != "latest" {
+		fmt.Printf("%#v\n", *spec.PostgresRecovery)
+		t.Fatalf("TargetTimeline should be 'latest', got '%s'", spec.PostgresRecovery.TargetTimeline)
+	}
+}

--- a/config/patroni_test.go
+++ b/config/patroni_test.go
@@ -3,13 +3,24 @@ package config
 import (
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 )
 
-func TestPatroni_(t *testing.T) {
+func patroniEnvForTesting() {
 	os.Clearenv()
+	os.Setenv("DINGO_IMAGE_VERSION", "0.0.0")
+	os.Setenv("DINGO_CLUSTER", "unittest")
+	os.Setenv("DINGO_ORG_TOKEN", "dummy")
+	os.Setenv("DINGO_API_URI", "localhost:3000")
+	os.Setenv("DINGO_PATRONI_DEFAULT_PATH", "../config/patroni-default-values.yml")
 	os.Setenv("DOCKER_HOST_IP", "10.11.12.13")
 	os.Setenv("DOCKER_HOST_PORT_5432", "5000")
+	os.Setenv("DOCKER_HOST_PORT_8008", "8000")
+}
+
+func TestPatroni_CreateURIFile(t *testing.T) {
+	patroniEnvForTesting()
 
 	patroniSpec := &PatroniV12Specification{}
 	patroniSpec.Postgresql.Authentication.Superuser.Username = "username"
@@ -26,5 +37,60 @@ func TestPatroni_(t *testing.T) {
 	expectedURI := "postgres://username:password@10.11.12.13:5000/postgres"
 	if string(uri) != expectedURI {
 		t.Fatalf("URI %s did not match expected %s", uri, expectedURI)
+	}
+}
+
+func TestPatroni_BasicPatroniSpec(t *testing.T) {
+	patroniEnvForTesting()
+
+	hostDiscoverySpec := &HostDiscoverySpecification{}
+	clusterSpec := &ClusterSpecification{}
+	overrideSpec := &OverrideSpecification{}
+
+	clusterSpec.Etcd.URI = "https://localhost:4001"
+	spec, err := BuildPatroniSpec(clusterSpec, hostDiscoverySpec, overrideSpec)
+	if err != nil {
+		t.Fatalf("Error creating patroni spec: %s", err)
+	}
+
+	if spec.Etcd.URL != clusterSpec.Etcd.URI {
+		t.Fatalf("Etcd.URL not setup")
+	}
+
+	if spec.Bootstrap.Dcs.Postgresql.RecoveryConf.RestoreCommand != "/scripts/restore_command.sh \"%p\" \"%f\"" {
+		t.Fatalf("recovery.conf's restore command should point to restore_command.sh")
+	}
+
+	if spec.Bootstrap.Dcs.Postgresql.RecoveryConf.TargetTimeline != "" {
+		t.Fatalf("recovery.conf's recovery_target_timeline should be empty by default")
+	}
+
+	if strings.Contains(spec.String(), "target_timeline") {
+		t.Fatalf("patroni.yml should not contain target_timeline if its not set")
+	}
+}
+
+func TestPatroni_PatroniSpec_CustomRecoverySettings(t *testing.T) {
+	patroniEnvForTesting()
+	os.Setenv("PG_RECOVERY_TARGET_TIMELINE", "latest")
+
+	hostDiscoverySpec := &HostDiscoverySpecification{}
+	clusterSpec := &ClusterSpecification{}
+	overrideSpec := OverrideSpec()
+	spec, err := BuildPatroniSpec(clusterSpec, hostDiscoverySpec, overrideSpec)
+	if err != nil {
+		t.Fatalf("Error creating patroni spec: %s", err)
+	}
+
+	if spec.Bootstrap.Dcs.Postgresql.RecoveryConf.RestoreCommand != "/scripts/restore_command.sh \"%p\" \"%f\"" {
+		t.Fatalf("recovery.conf's restore command should point to restore_command.sh")
+	}
+
+	if spec.Bootstrap.Dcs.Postgresql.RecoveryConf.TargetTimeline != "latest" {
+		t.Fatalf("recovery.conf's recovery_target_timeline should be 'latest' from $PG_RECOVERY_TARGET_TIMELINE")
+	}
+
+	if !strings.Contains(spec.String(), "target_timeline") {
+		t.Fatalf("patroni.yml should contain target_timeline if its not set")
 	}
 }


### PR DESCRIPTION
Known recovery.conf settings documented at https://www.postgresql.org/docs/9.5/static/recovery-target-settings.html

To configure any setting, such as `recovery_target_timeline`, provide the
Docker container with a `PG_RECOVERY_TARGET_TIMELINE` variable.

For example:

```
docker run -e PG_RECOVERY_TARGET_TIMELINE=latest ... dingotiles/dingo-postgresql:pitr
```

Will result in a /config/patroni.yml that contains:

```yaml
bootstrap:
  dcs:
    postgresql:
      recovery_conf:
        restore_command: /scripts/restore_command.sh "%p" "%f"
        recovery_target_timeline: latest
```

To test this PR, there is a `:pitr` tagged image on docker hub:

```
docker pull dingotiles/dingo-postgresql:pitr
docker run dingotiles/dingo-postgresql:pitr
```

To recover an existing dingo container, delete it, then re-run it using the same env var settings, but:

1) Use `dingotiles/dingo-postgresql:pitr` image
2) Pass in `-e PG_RECOVERY_XXX` env vars to control point in time recovery
